### PR TITLE
Use correct pattern_esc for lookup

### DIFF
--- a/django_singlestore/base.py
+++ b/django_singlestore/base.py
@@ -144,7 +144,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     #
     # Note: we use str.format() here for readability as '%' is used as a wildcard for
     # the LIKE operator.
-    pattern_esc = r"REPLACE(REPLACE(REPLACE({}, '\\', '\\\\'), '%', '\%'), '_', '\_')"
+    pattern_esc = r"REPLACE(REPLACE(REPLACE({}, '\\', '\\\\'), '%%', '\%%'), '_', '\_')"
     pattern_ops = {
         "contains": "LIKE BINARY CONCAT('%%', {}, '%%')",
         "icontains": "LIKE CONCAT('%%', {}, '%%')",

--- a/django_singlestore/features.py
+++ b/django_singlestore/features.py
@@ -648,6 +648,9 @@ table' is not supported by SingleStore":  # TODO: check if we can run these test
             "delete_regress.tests.Ticket19102Tests.test_ticket_19102_annotate",
             # we issue two queries instead of one, and 2 additional queries: BEGIN and COMMIT
             "many_to_many.tests.ManyToManyTests.test_fast_add_ignore_conflicts",
+            # TODO: PLAT-7420 after singlestoredb-python update these two should be fixed
+            "expressions.tests.ExpressionsTests.test_patterns_escape",
+            "expressions.tests.ExpressionsTests.test_insensitive_patterns_escape",
         }
 
         return fails

--- a/django_singlestore/operations.py
+++ b/django_singlestore/operations.py
@@ -70,10 +70,10 @@ class DatabaseOperations(BaseDatabaseOperations):
         sql, params = self._convert_field_to_tz(sql, params, tzname)
         if tzname:
             sql = f"CONVERT_TZ({sql}, %s, 'UTC')"
-            params.append(tzname)
+            params = (*params, tzname)
 
         trunc_sql = f"DATE_TRUNC(%s, {sql})"
-        params.insert(0, lookup_type)
+        params = (lookup_type, *params)
 
         return trunc_sql, params
 
@@ -114,11 +114,11 @@ class DatabaseOperations(BaseDatabaseOperations):
         if tzname:
             # Adjust the datetime field to the specified timezone
             sql = f"CONVERT_TZ({sql}, %s, 'UTC')"
-            params.append(tzname)
+            params = (*params, tzname)
 
         # Use SingleStore's DATE_TRUNC function to truncate the datetime
         trunc_sql = f"DATE_TRUNC(%s, {sql})"
-        params.insert(0, lookup_type)
+        params = (lookup_type, *params)
 
         return trunc_sql, params
 


### PR DESCRIPTION
`pattern_esc` was modified to work with expressions tests (that are failing after this PR), but in strings that can  be formatted later (with `formatted_str = my_str % args`) we should replace literal `%` with `%%` so that `%` not confused with a string formatting argument. In some tests string is not formatted with `%`, so they fail, and it's a problem in the underlying python driver.