### PR TITLE
delete older codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @singlestore-labs/connectors


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Process-only change to GitHub review routing; no application, security, or runtime behavior is affected.
> 
> **Overview**
> Removes **`.github/CODEOWNERS`**, which previously assigned **`@singlestore-labs/connectors`** as the default owner for all paths (`*`). PRs will no longer automatically request that team via this file unless ownership is defined elsewhere (e.g. another CODEOWNERS path or org settings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 643b9b0f74d89d007b3e743d02bc03c962ac4585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->